### PR TITLE
Resolve merge conflicts and rebase for PR1963

### DIFF
--- a/ntc_templates/templates/hp_comware_display_interface.textfsm
+++ b/ntc_templates/templates/hp_comware_display_interface.textfsm
@@ -28,7 +28,7 @@ Start
   ^\s*The\sMaximum\s+Transmit\s+Unit\sis\s+${MTU}
   ^\s*Maximum\s+frame\s+length:\s+${L2MTU}
   ^\s*Forbid\s+jumbo\s+frames\s+to\s+pass
-  ^\s*The\sMaximum\s+Frame\s+Length\sis\s+${L2MTU}
+  ^\s*The\s[Mm]aximum\s+[Ff]rame\s+[Ll]ength\sis\s+${L2MTU}
   ^\s*Internet\s+[Aa]ddress:\s+${IP_ADDRESS}\s+\([Pp]rimary\)
   ^\s*Internet\s+[Aa]ddress\sis\s+${IP_ADDRESS}\s+[Pp]rimary
   ^\s*Internet\s+[Aa]ddress:\s+${IP_ADDRESS}\s+\([Ss]ub\)

--- a/ntc_templates/templates/hp_comware_display_interface.textfsm
+++ b/ntc_templates/templates/hp_comware_display_interface.textfsm
@@ -180,7 +180,7 @@ Start
   ^\s*GRE
   ^\s*Checksumming\sof\sGRE
   ^\s+-\s+ignored
-  ^\s+[-\d]+\s+frame
+  ^\s+(-|\d+)\s+frame
   ^\s+-\s+aborts
   ^\s+-\s+lost\s+carrier
   ^\s*DCD:

--- a/ntc_templates/templates/hp_comware_display_interface.textfsm
+++ b/ntc_templates/templates/hp_comware_display_interface.textfsm
@@ -180,7 +180,7 @@ Start
   ^\s*GRE
   ^\s*Checksumming\sof\sGRE
   ^\s+-\s+ignored
-  ^\s+-\s+frame
+  ^\s+[-\d]+\s+frame
   ^\s+-\s+aborts
   ^\s+-\s+lost\s+carrier
   ^\s*DCD:

--- a/ntc_templates/templates/hp_comware_display_interface.textfsm
+++ b/ntc_templates/templates/hp_comware_display_interface.textfsm
@@ -25,12 +25,12 @@ Start
   ^\s*Description:\s+${DESCRIPTION}
   ^\s*Bandwidth:\s+${BANDWIDTH}
   ^\s*Maximum\s+[Tt]ransmi\S+\s+[Uu]nit:\s+${MTU}
-  ^\s*The\sMaximum\s+Transmit\s+Unit\sis\s+${MTU}
+  ^\s*The\s+Maximum\s+Transmit\s+Unit\s+is\s+${MTU}
   ^\s*Maximum\s+frame\s+length:\s+${L2MTU}
   ^\s*Forbid\s+jumbo\s+frames\s+to\s+pass
-  ^\s*The\s[Mm]aximum\s+[Ff]rame\s+[Ll]ength\sis\s+${L2MTU}
+  ^\s*The\s+Maximum\s+Frame\s+Length\s+is\s+${L2MTU}
   ^\s*Internet\s+[Aa]ddress:\s+${IP_ADDRESS}\s+\([Pp]rimary\)
-  ^\s*Internet\s+[Aa]ddress\sis\s+${IP_ADDRESS}\s+[Pp]rimary
+  ^\s*Internet\s+[Aa]ddress\s+is\s+${IP_ADDRESS}\s+[Pp]rimary
   ^\s*Internet\s+[Aa]ddress:\s+${IP_ADDRESS}\s+\([Ss]ub\)
   ^\s*IP\s+[Pp]acket\s+[Ff]rame\s+[Tt]ype\s*:\s*[^,]+,\s+[Hh]ardware\s+[Aa]ddress:\s+${HW_ADDRESS}
   ^\s*IPv6\s+[Pp]acket\s+[Ff]rame\s+[Tt]ype\s*:\s*[^,]+,\s+[Hh]ardware\s+[Aa]ddress:\s+${HW_ADDRESS}
@@ -148,7 +148,7 @@ Start
   ^\s*Broadcast
   ^\s*Multicast
   ^\s*Unicast
-  ^\s*No\sconnector
+  ^\s*No\s+connector
   ^\s*M[Dd][Ii]\s+type
   ^\s*Port\s+priority
   ^\s*Current\s*system
@@ -178,7 +178,7 @@ Start
   ^\s+\d+\s+dribbles
   ^\s*Tunnel\s
   ^\s*GRE
-  ^\s*Checksumming\sof\sGRE
+  ^\s*Checksumming\s+of\s+GRE
   ^\s+-\s+ignored
   ^\s+(-|\d+)\s+frame
   ^\s+-\s+aborts

--- a/ntc_templates/templates/hp_comware_display_interface.textfsm
+++ b/ntc_templates/templates/hp_comware_display_interface.textfsm
@@ -28,7 +28,7 @@ Start
   ^\s*The\s+Maximum\s+Transmit\s+Unit\s+is\s+${MTU}
   ^\s*Maximum\s+frame\s+length:\s+${L2MTU}
   ^\s*Forbid\s+jumbo\s+frames\s+to\s+pass
-  ^\s*The\s+Maximum\s+Frame\s+Length\s+is\s+${L2MTU}
+  ^\s*The\s+[Mm]aximum\s+[Ff]rame\s+[Ll]ength\s+is\s+${L2MTU}
   ^\s*Internet\s+[Aa]ddress:\s+${IP_ADDRESS}\s+\([Pp]rimary\)
   ^\s*Internet\s+[Aa]ddress\s+is\s+${IP_ADDRESS}\s+[Pp]rimary
   ^\s*Internet\s+[Aa]ddress:\s+${IP_ADDRESS}\s+\([Ss]ub\)

--- a/tests/hp_comware/display_interface/hp_comware_display_interface10.raw
+++ b/tests/hp_comware/display_interface/hp_comware_display_interface10.raw
@@ -1,0 +1,154 @@
+FortyGigE2/0/30
+Current state: UP
+IP packet frame type: Ethernet II, hardware address: ec9b-8b87-6ebb
+Description: DescriptionSanitized
+Bandwidth: 40000000 kbps
+Loopback is not set
+Media type is optical fiber, port hardware type is 40G_BASE_LR4_QSFP_PLUS
+40Gbps-speed mode, full-duplex mode
+Link speed type is autonegotiation, link duplex type is autonegotiation
+Maximum frame length: 1500
+MDI type: Automdix
+Last link flapping: 14 weeks 4 days 22 hours 58 minutes
+Last clearing of counters: Never
+ Peak input rate: 36118838 bytes/sec, at 2024-12-12 15:01:44 
+ Peak output rate: 26480533 bytes/sec, at 2024-10-20 01:40:54 
+ Last 300 second input: 785 packets/sec 427679 bytes/sec 0%
+ Last 300 second output: 87 packets/sec 18859 bytes/sec 0%
+ Input (total):  70305212465 packets, 16984268010832 bytes
+         65808897390 unicasts, 1909665019 broadcasts, 2586650056 multicasts, 0 pauses
+ Input (normal):  70305212465 packets, - bytes
+         65808897390 unicasts, 1909665019 broadcasts, 2586650056 multicasts, 0 pauses
+ Input:  0 input errors, 0 runts, 0 giants, 0 throttles
+         0 CRC, 0 frame, - overruns, 0 aborts
+         - ignored, - parity errors
+ Output (total): 503558376 packets, 152287197755 bytes
+         450547961 unicasts, 19235889 broadcasts, 33774526 multicasts, 0 pauses
+ Output (normal): 503558376 packets, - bytes
+         450547961 unicasts, 19235889 broadcasts, 33774526 multicasts, 0 pauses
+ Output: 0 output errors, - underruns, - buffer failures
+         0 aborts, 0 deferred, 0 collisions, 0 late collisions
+         0 lost carrier, - no carrier
+
+FortyGigE2/0/31
+Current state: UP
+Line protocol state: UP
+Description: DescriptionSanitized
+Bandwidth: 40000000 kbps
+Maximum transmission unit: 9008
+Allow jumbo frames to pass
+Broadcast max-ratio: 100%
+Multicast max-ratio: 100%
+Unicast max-ratio: 100%
+Internet address: 1.2.3.4/30 (primary)
+IP packet frame type: Ethernet II, hardware address: ec9b-8b87-6712
+IPv6 packet frame type: Ethernet II, hardware address: ec9b-8b87-6712
+Loopback is not set
+Media type is optical fiber, port hardware type is 40G_BASE_LR4L_QSFP_PLUS
+Port priority: 0
+40Gbps-speed mode, full-duplex mode
+Link speed type is autonegotiation, link duplex type is autonegotiation
+Flow-control is not enabled
+The maximum frame length is 10000
+Last link flapping: 14 weeks 4 days 22 hours 58 minutes
+Last clearing of counters: Never
+ Peak input rate: 1092779782 bytes/sec, at 2024-11-19 11:21:23 
+ Peak output rate: 1290025339 bytes/sec, at 2024-10-27 02:47:45 
+ Last 300 second input: 121027 packets/sec 96927232 bytes/sec 1%
+ Last 300 second output: 164684 packets/sec 195424831 bytes/sec 3%
+ Input (total):  1079870545982 packets, 1102625609428051 bytes
+         1079867808511 unicasts, 2 broadcasts, 2737469 multicasts, 0 pauses
+ Input (normal):  1079870545802 packets, - bytes
+         1079867808492 unicasts, 2 broadcasts, 2737469 multicasts, 0 pauses
+ Input:  0 input errors, 0 runts, 0 giants, 0 throttles
+         0 CRC, 0 frame, - overruns, 0 aborts
+         - ignored, - parity errors
+ Output (total): 1584478018814 packets, 1749641174315111 bytes
+         1584428578218 unicasts, 5 broadcasts, 49440591 multicasts, 0 pauses
+ Output (normal): 1584478018768 packets, - bytes
+         1584428578189 unicasts, 5 broadcasts, 49440591 multicasts, 0 pauses
+ Output: 0 output errors, - underruns, - buffer failures
+         0 aborts, 0 deferred, 0 collisions, 0 late collisions
+         0 lost carrier, - no carrier
+
+FortyGigE2/0/32
+Current state: UP
+Line protocol state: UP
+Description: DescriptionSanitized
+Bandwidth: 40000000 kbps
+Maximum transmission unit: 9008
+Allow jumbo frames to pass
+Broadcast max-ratio: 100%
+Multicast max-ratio: 100%
+Unicast max-ratio: 100%
+Internet address: 2.3.4.5/30 (primary)
+IP packet frame type: Ethernet II, hardware address: ec9b-8b87-6712
+IPv6 packet frame type: Ethernet II, hardware address: ec9b-8b87-6712
+Loopback is not set
+Media type is optical fiber, port hardware type is 40G_BASE_LR4L_QSFP_PLUS
+Port priority: 0
+40Gbps-speed mode, full-duplex mode
+Link speed type is autonegotiation, link duplex type is autonegotiation
+Flow-control is not enabled
+The maximum frame length is 10000
+Last link flapping: 14 weeks 4 days 22 hours 58 minutes
+Last clearing of counters: Never
+ Peak input rate: 1107838242 bytes/sec, at 2024-11-18 11:16:43 
+ Peak output rate: 1820915311 bytes/sec, at 2024-11-01 02:39:51 
+ Last 300 second input: 94727 packets/sec 73711786 bytes/sec 1%
+ Last 300 second output: 228364 packets/sec 277463565 bytes/sec 5%
+ Input (total):  1209343749313 packets, 1171816530005832 bytes
+         1209341011832 unicasts, 2 broadcasts, 2737479 multicasts, 0 pauses
+ Input (normal):  1209343749196 packets, - bytes
+         1209341011815 unicasts, 2 broadcasts, 2737479 multicasts, 0 pauses
+ Input:  0 input errors, 0 runts, 0 giants, 0 throttles
+         0 CRC, 0 frame, - overruns, 0 aborts
+         - ignored, - parity errors
+ Output (total): 2023879506096 packets, 2420341456820046 bytes
+         2023828309222 unicasts, 5 broadcasts, 51196869 multicasts, 0 pauses
+ Output (normal): 2023879505998 packets, - bytes
+         2023828309204 unicasts, 5 broadcasts, 51196869 multicasts, 0 pauses
+ Output: 0 output errors, - underruns, - buffer failures
+         0 aborts, 0 deferred, 0 collisions, 0 late collisions
+         0 lost carrier, - no carrier
+
+FortyGigE2/0/33
+Current state: UP
+Line protocol state: UP
+Description: DescriptionSanitized
+Bandwidth: 40000000 kbps
+Maximum transmission unit: 9008
+Allow jumbo frames to pass
+Broadcast max-ratio: 100%
+Multicast max-ratio: 100%
+Unicast max-ratio: 100%
+Internet address: 2.3.4.5/30 (primary)
+IP packet frame type: Ethernet II, hardware address: ec9b-8b87-6712
+IPv6 packet frame type: Ethernet II, hardware address: ec9b-8b87-6712
+Loopback is not set
+Media type is optical fiber, port hardware type is 40G_BASE_LR4L_QSFP_PLUS
+Port priority: 0
+40Gbps-speed mode, full-duplex mode
+Link speed type is autonegotiation, link duplex type is autonegotiation
+Flow-control is not enabled
+The Maximum Frame Length is 10000
+Last link flapping: 14 weeks 4 days 22 hours 58 minutes
+Last clearing of counters: Never
+ Peak input rate: 1107838242 bytes/sec, at 2024-11-18 11:16:43 
+ Peak output rate: 1820915311 bytes/sec, at 2024-11-01 02:39:51 
+ Last 300 second input: 94727 packets/sec 73711786 bytes/sec 1%
+ Last 300 second output: 228364 packets/sec 277463565 bytes/sec 5%
+ Input (total):  1209343749313 packets, 1171816530005832 bytes
+         1209341011832 unicasts, 2 broadcasts, 2737479 multicasts, 0 pauses
+ Input (normal):  1209343749196 packets, - bytes
+         1209341011815 unicasts, 2 broadcasts, 2737479 multicasts, 0 pauses
+ Input:  0 input errors, 0 runts, 0 giants, 0 throttles
+         0 CRC, 0 frame, - overruns, 0 aborts
+         - ignored, - parity errors
+ Output (total): 2023879506096 packets, 2420341456820046 bytes
+         2023828309222 unicasts, 5 broadcasts, 51196869 multicasts, 0 pauses
+ Output (normal): 2023879505998 packets, - bytes
+         2023828309204 unicasts, 5 broadcasts, 51196869 multicasts, 0 pauses
+ Output: 0 output errors, - underruns, - buffer failures
+         0 aborts, 0 deferred, 0 collisions, 0 late collisions
+         0 lost carrier, - no carrier

--- a/tests/hp_comware/display_interface/hp_comware_display_interface10.yml
+++ b/tests/hp_comware/display_interface/hp_comware_display_interface10.yml
@@ -1,0 +1,76 @@
+---
+parsed_sample:
+  - bandwidth: "40000000 kbps"
+    description: "DescriptionSanitized"
+    duplex: "full-duplex"
+    hw_address:
+      - "ec9b-8b87-6ebb"
+    interface: "FortyGigE2/0/30"
+    ip_address: []
+    l2mtu: "1500"
+    line_status: "UP"
+    mtu: ""
+    port_link_type: ""
+    protocol_status: ""
+    speed: "40Gbps-speed"
+    untagged_vlan_id: ""
+    vlan_native: ""
+    vlan_passing: []
+    vlan_permitted: []
+  - bandwidth: "40000000 kbps"
+    description: "DescriptionSanitized"
+    duplex: "full-duplex"
+    hw_address:
+      - "ec9b-8b87-6712"
+      - "ec9b-8b87-6712"
+    interface: "FortyGigE2/0/31"
+    ip_address:
+      - "1.2.3.4/30"
+    l2mtu: "10000"
+    line_status: "UP"
+    mtu: "9008"
+    port_link_type: ""
+    protocol_status: "UP"
+    speed: "40Gbps-speed"
+    untagged_vlan_id: ""
+    vlan_native: ""
+    vlan_passing: []
+    vlan_permitted: []
+  - bandwidth: "40000000 kbps"
+    description: "DescriptionSanitized"
+    duplex: "full-duplex"
+    hw_address:
+      - "ec9b-8b87-6712"
+      - "ec9b-8b87-6712"
+    interface: "FortyGigE2/0/32"
+    ip_address:
+      - "2.3.4.5/30"
+    l2mtu: "10000"
+    line_status: "UP"
+    mtu: "9008"
+    port_link_type: ""
+    protocol_status: "UP"
+    speed: "40Gbps-speed"
+    untagged_vlan_id: ""
+    vlan_native: ""
+    vlan_passing: []
+    vlan_permitted: []
+  - bandwidth: "40000000 kbps"
+    description: "DescriptionSanitized"
+    duplex: "full-duplex"
+    hw_address:
+      - "ec9b-8b87-6712"
+      - "ec9b-8b87-6712"
+    interface: "FortyGigE2/0/33"
+    ip_address:
+      - "2.3.4.5/30"
+    l2mtu: "10000"
+    line_status: "UP"
+    mtu: "9008"
+    port_link_type: ""
+    protocol_status: "UP"
+    speed: "40Gbps-speed"
+    untagged_vlan_id: ""
+    vlan_native: ""
+    vlan_passing: []
+    vlan_permitted: []

--- a/tests/hp_comware/display_interface/hp_comware_display_interface_numeric-frame.raw
+++ b/tests/hp_comware/display_interface/hp_comware_display_interface_numeric-frame.raw
@@ -1,0 +1,54 @@
+ Bridge-Aggregation11 current state: UP
+ IP Packet Frame Type: PKTFMT_ETHNT_2, Hardware Address: 2c23-3afc-8bf9
+ Description: mydescr
+ 20Gbps-speed mode, full-duplex mode
+ Link speed type is autonegotiation, link duplex type is autonegotiation
+ PVID: 4094
+ Port link-type: trunk
+  VLAN passing  : 201-212
+  VLAN permitted: 201-212
+  Trunk port encapsulation: IEEE 802.1q
+ Last clearing of counters:  Never
+ Last 300 seconds input:  0 packets/sec 8 bytes/sec    0%
+ Last 300 seconds output:  58 packets/sec 10067 bytes/sec    0%
+ Input (total):  879620774593 packets, 757707436249911 bytes
+         879438947612 unicasts, 177384844 broadcasts, 4442137 multicasts
+ Input (normal):  879620774593 packets, - bytes
+         879438947612 unicasts, 177384844 broadcasts, 4442137 multicasts
+ Input:  0 input errors, 0 runts, 0 giants, 0 throttles
+         0 CRC, 0 frame, - overruns, 0 aborts
+         - ignored, - parity errors
+ Output (total): 714267170700 packets, 452933870007295 bytes
+         709437724867 unicasts, 2905418797 broadcasts, 1924027036 multicasts, 0 pauses
+ Output (normal): 714267170700 packets, - bytes
+         709437724867 unicasts, 2905418797 broadcasts, 1924027036 multicasts, 0 pauses
+ Output: 0 output errors, - underruns, - buffer failures
+         0 aborts, 0 deferred, 0 collisions, 0 late collisions
+         0 lost carrier, - no carrier
+
+ Bridge-Aggregation66 current state: DOWN
+ IP Packet Frame Type: PKTFMT_ETHNT_2, Hardware Address: 2c23-3afc-8bc0
+ Description: mydescr
+ Unknown-speed mode, unknown-duplex mode
+ Link speed type is autonegotiation, link duplex type is autonegotiation
+ PVID: 1
+ Port link-type: access
+  Tagged   VLAN ID : none
+  Untagged VLAN ID : 1
+ Last clearing of counters:  Never
+ Last 300 seconds input:  0 packets/sec 0 bytes/sec    -%
+ Last 300 seconds output:  0 packets/sec 0 bytes/sec    -%
+ Input (total):  0 packets, 0 bytes
+         0 unicasts, 0 broadcasts, 0 multicasts
+ Input (normal):  0 packets, 0 bytes
+         0 unicasts, 0 broadcasts, 0 multicasts
+ Input:  0 input errors, 0 runts, 0 giants, 0 throttles
+         0 CRC, 0 frame, 0 overruns, 0 aborts
+         0 ignored, 0 parity errors
+ Output (total): 0 packets, 0 bytes
+         0 unicasts, 0 broadcasts, 0 multicasts, 0 pauses
+ Output (normal): 0 packets, 0 bytes
+         0 unicasts, 0 broadcasts, 0 multicasts, 0 pauses
+ Output: 0 output errors, 0 underruns, 0 buffer failures
+         0 aborts, 0 deferred, 0 collisions, 0 late collisions
+         0 lost carrier, 0 no carrier

--- a/tests/hp_comware/display_interface/hp_comware_display_interface_numeric-frame.yml
+++ b/tests/hp_comware/display_interface/hp_comware_display_interface_numeric-frame.yml
@@ -1,0 +1,38 @@
+---
+parsed_sample:
+  - bandwidth: ""
+    description: "mydescr"
+    duplex: "full-duplex"
+    hw_address:
+      - "2c23-3afc-8bf9"
+    interface: "Bridge-Aggregation11"
+    ip_address: []
+    l2mtu: ""
+    line_status: "UP"
+    mtu: ""
+    port_link_type: "trunk"
+    protocol_status: ""
+    speed: "20Gbps-speed"
+    untagged_vlan_id: ""
+    vlan_native: "4094"
+    vlan_passing:
+      - "201-212"
+    vlan_permitted:
+      - "201-212"
+  - bandwidth: ""
+    description: "mydescr"
+    duplex: "unknown-duplex"
+    hw_address:
+      - "2c23-3afc-8bc0"
+    interface: "Bridge-Aggregation66"
+    ip_address: []
+    l2mtu: ""
+    line_status: "DOWN"
+    mtu: ""
+    port_link_type: "access"
+    protocol_status: ""
+    speed: "Unknown-speed"
+    untagged_vlan_id: "1"
+    vlan_native: "1"
+    vlan_passing: []
+    vlan_permitted: []


### PR DESCRIPTION
Addition to https://github.com/networktocode/ntc-templates/pull/1963

* Resolve merge conflicts
   * Moved Julien's test data files suffixed with "10" to "_numeric-frame"
   * Left PR #1982's test data at "10"
* Add some future-proofed whitespace matching for a pattern

Thank you!